### PR TITLE
include cell image name in the deployment name 🔥

### DIFF
--- a/pkg/controller/cell/resources/gateway.go
+++ b/pkg/controller/cell/resources/gateway.go
@@ -38,9 +38,10 @@ func CreateGateway(cell *v1alpha1.Cell) *v1alpha1.Gateway {
 
 	return &v1alpha1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GatewayName(cell),
-			Namespace: cell.Namespace,
-			Labels:    createLabels(cell),
+			Name:        GatewayName(cell),
+			Namespace:   cell.Namespace,
+			Labels:      createLabels(cell),
+			Annotations: createAnnotations(cell),
 			OwnerReferences: []metav1.OwnerReference{
 				*controller.CreateCellOwnerRef(cell),
 			},

--- a/pkg/controller/cell/resources/meta.go
+++ b/pkg/controller/cell/resources/meta.go
@@ -33,7 +33,7 @@ func createLabels(cell *v1alpha1.Cell) map[string]string {
 	return labels
 }
 
-func createServiceAnnotations(cell *v1alpha1.Cell) map[string]string {
+func createAnnotations(cell *v1alpha1.Cell) map[string]string {
 	annotations := make(map[string]string, len(cell.ObjectMeta.Annotations))
 
 	for k, v := range cell.ObjectMeta.Annotations {

--- a/pkg/controller/cell/resources/service.go
+++ b/pkg/controller/cell/resources/service.go
@@ -50,7 +50,7 @@ func CreateService(cell *v1alpha1.Cell, serviceTemplate v1alpha1.ServiceTemplate
 			Name:        ServiceName(cell, serviceTemplate),
 			Namespace:   cell.Namespace,
 			Labels:      createLabels(cell),
-			Annotations: createServiceAnnotations(cell),
+			Annotations: createAnnotations(cell),
 			OwnerReferences: []metav1.OwnerReference{
 				*controller.CreateCellOwnerRef(cell),
 			},

--- a/pkg/controller/cell/resources/token_service.go
+++ b/pkg/controller/cell/resources/token_service.go
@@ -31,6 +31,7 @@ func CreateTokenService(cell *v1alpha1.Cell) *v1alpha1.TokenService {
 			Name:      TokenServiceName(cell),
 			Namespace: cell.Namespace,
 			Labels:    createLabels(cell),
+			Annotations: createAnnotations(cell),
 			OwnerReferences: []metav1.OwnerReference{
 				*controller.CreateCellOwnerRef(cell),
 			},

--- a/pkg/controller/constants.go
+++ b/pkg/controller/constants.go
@@ -25,6 +25,11 @@ const (
 	// Istio
 	IstioSidecarInjectAnnotation = "sidecar.istio.io/inject"
 
+	// Image annotations
+	CellImageNameAnnotation = "mesh.cellery.io/cell-image-name";
+	CellImageVersionAnnotation = "mesh.cellery.io/cell-image-version"
+	CellImageOrgAnnotation = "mesh.cellery.io/cell-image-org"
+
 	// Names
 	HTTPServiceName = "http"
 )

--- a/pkg/controller/gateway/resources/meta.go
+++ b/pkg/controller/gateway/resources/meta.go
@@ -19,6 +19,7 @@
 package resources
 
 import (
+	"github.com/cellery-io/mesh-controller/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cellery-io/mesh-controller/pkg/apis/mesh"
@@ -45,6 +46,10 @@ func GatewayConfigMapName(gateway *v1alpha1.Gateway) string {
 }
 
 func GatewayDeploymentName(gateway *v1alpha1.Gateway) string {
+	imageName, _, _ := extractImageInfo(gateway)
+	if len(imageName) > 0 {
+		return imageName + "-" + gateway.Name + "-deployment"
+	}
 	return gateway.Name + "-deployment"
 }
 
@@ -70,4 +75,14 @@ func GatewayFullK8sServiceName(gateway *v1alpha1.Gateway) string {
 
 func IstioDestinationRuleName(gateway *v1alpha1.Gateway) string {
 	return gateway.Name + "-destination-rule"
+}
+
+func extractImageInfo(gateway *v1alpha1.Gateway) (string, string, string) {
+	annotations := gateway.Annotations
+	if annotations == nil || len(annotations) == 0 {
+		// no annotations found
+		return "", "", ""
+	}
+	return annotations[controller.CellImageNameAnnotation],
+		annotations[controller.CellImageVersionAnnotation], annotations[controller.CellImageOrgAnnotation]
 }

--- a/pkg/controller/service/resources/meta.go
+++ b/pkg/controller/service/resources/meta.go
@@ -19,6 +19,7 @@
 package resources
 
 import (
+	"github.com/cellery-io/mesh-controller/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cellery-io/mesh-controller/pkg/apis/mesh"
@@ -43,6 +44,10 @@ func createSelector(service *v1alpha1.Service) *metav1.LabelSelector {
 }
 
 func ServiceDeploymentName(service *v1alpha1.Service) string {
+	imageName, _, _ := extractImageInfo(service)
+	if len(imageName) > 0 {
+		return imageName + "-" + service.Name + "-deployment"
+	}
 	return service.Name + "-deployment"
 }
 
@@ -52,4 +57,14 @@ func ServiceK8sServiceName(service *v1alpha1.Service) string {
 
 func ServiceHpaName(service *v1alpha1.Service) string {
 	return service.Name + "-hpa"
+}
+
+func extractImageInfo(service *v1alpha1.Service) (string, string, string) {
+	annotations := service.Annotations
+	if annotations == nil || len(annotations) == 0 {
+		// no annotations found
+		return "", "", ""
+	}
+	return annotations[controller.CellImageNameAnnotation],
+		annotations[controller.CellImageVersionAnnotation], annotations[controller.CellImageOrgAnnotation]
 }

--- a/pkg/controller/sts/resources/meta.go
+++ b/pkg/controller/sts/resources/meta.go
@@ -19,6 +19,7 @@
 package resources
 
 import (
+	"github.com/cellery-io/mesh-controller/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cellery-io/mesh-controller/pkg/apis/mesh"
@@ -48,9 +49,23 @@ func TokenServicePolicyConfigMapName(tokenService *v1alpha1.TokenService) string
 }
 
 func TokenServiceDeploymentName(tokenService *v1alpha1.TokenService) string {
+	imageName, _, _ := extractImageInfo(tokenService)
+	if len(imageName) > 0 {
+		return imageName + "-" + tokenService.Name + "-deployment"
+	}
 	return tokenService.Name + "-deployment"
 }
 
 func TokenServiceK8sServiceName(tokenService *v1alpha1.TokenService) string {
 	return tokenService.Name + "-service"
+}
+
+func extractImageInfo(tokenService *v1alpha1.TokenService) (string, string, string) {
+	annotations := tokenService.Annotations
+	if annotations == nil || len(annotations) == 0 {
+		// no annotations found
+		return "", "", ""
+	}
+	return annotations[controller.CellImageNameAnnotation],
+		annotations[controller.CellImageVersionAnnotation], annotations[controller.CellImageOrgAnnotation]
 }


### PR DESCRIPTION
## Purpose
> Include the cell image name in all deployments created. The new format would be **<image name>-<instance name>--<image name>-deployment**. For an example, for employee cell with instance name employeeapp, the deployment name would be employee-employeeapp--employee-deployment. 