### PR TITLE
support specific secured paths

### DIFF
--- a/pkg/apis/mesh/v1alpha1/gateway_types.go
+++ b/pkg/apis/mesh/v1alpha1/gateway_types.go
@@ -58,6 +58,7 @@ type OidcConfig struct {
 	RedirectUrl    string   `json:"redirectUrl"`
 	BaseUrl        string   `json:"baseUrl"`
 	SubjectClaim   string   `json:"subjectClaim"`
+	SecurePaths    []string `json:"securePaths,omitempty"`
 	NonSecurePaths []string `json:"nonSecurePaths,omitempty"`
 }
 

--- a/pkg/controller/gateway/resources/deployment.go
+++ b/pkg/controller/gateway/resources/deployment.go
@@ -325,6 +325,10 @@ func createEnvoyGatewayDeployment(gateway *v1alpha1.Gateway, gatewayConfig confi
 					Name:  "NON_SECURE_PATHS",
 					Value: strings.Join(oidc.NonSecurePaths, ","),
 				},
+				{
+					Name:  "SECURE_PATHS",
+					Value: strings.Join(oidc.SecurePaths, ","),
+				},
 			},
 			Ports: []corev1.ContainerPort{
 				{

--- a/samples/pet-store-yamls/pet-frontend.yaml
+++ b/samples/pet-store-yamls/pet-frontend.yaml
@@ -20,6 +20,8 @@ spec:
         subjectClaim: given_name
 #        nonSecurePaths:
 #          - "/items/*"
+#        securePaths:
+#          - "/items/*"
       http:
       - context: items
         definitions:


### PR DESCRIPTION
## Purpose
> Secured paths can be specified in the cell definition as follows:
  oidc:
   ...
    redirectUrl: http://pet-store.com/_auth/callback
    baseUrl: http://pet-store.com/items/
    subjectClaim: given_name
    securePaths:
      - "/items/orders/*"