### PR TITLE
add autoscalepolicies resource permission to mesh controller

### DIFF
--- a/artifacts/01-cluster-role.yaml
+++ b/artifacts/01-cluster-role.yaml
@@ -89,6 +89,7 @@ rules:
   - services
   - gateways
   - tokenservices
+  - autoscalepolicies
   verbs:
   - get
   - list


### PR DESCRIPTION
## Purpose
> add permission for the resource autoscalepolicies to mesh.cellery.io api group. 