### PR TITLE
Add knative concurrency metric to autoscalar

### DIFF
--- a/pkg/apis/mesh/v1alpha1/autoscaling_types.go
+++ b/pkg/apis/mesh/v1alpha1/autoscaling_types.go
@@ -44,6 +44,7 @@ type Policy struct {
 	MinReplicas    *int32                                         `json:"minReplicas"`
 	MaxReplicas    int32                                          `json:"maxReplicas"`
 	Metrics        []autoscalingV2beta1.MetricSpec                `json:"metrics"`
+	Concurrency    int64                                          `json:"concurrency"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/service/resources/serving.go
+++ b/pkg/controller/service/resources/serving.go
@@ -66,6 +66,13 @@ func CreateZeroScaleService(service *v1alpha1.Service) *servingv1alpha1.Configur
 								service.Spec.Container,
 							},
 						},
+						ContainerConcurrency: func() servingv1beta1.RevisionContainerConcurrencyType {
+							c := service.Spec.Autoscaling.Policy.Concurrency
+							if c < 1 {
+								return 0
+							}
+							return servingv1beta1.RevisionContainerConcurrencyType(c)
+						}(),
 					},
 				},
 			},


### PR DESCRIPTION
Add knative concurrency metric to autoscalar

Related: https://github.com/wso2-cellery/sdk/issues/419