### PR TITLE
using the correct cell instance to generate routes

### DIFF
--- a/pkg/controller/cell/resources/virtual_svc.go
+++ b/pkg/controller/cell/resources/virtual_svc.go
@@ -86,7 +86,7 @@ func buildInterCellRoutingInfo(cell *v1alpha1.Cell, cellLister listers.CellListe
 		if len(depCell.Spec.GatewayTemplate.Spec.HTTPRoutes) > 0 {
 			hostNames = append(hostNames, buildHostName(dependencyInst))
 			// build http routes
-			intercellHttpRoutes = append(intercellHttpRoutes, buildHttpRoute(depCell, dependencyInst))
+			intercellHttpRoutes = append(intercellHttpRoutes, buildHttpRoute(cell, dependencyInst))
 		}
 		if len(depCell.Spec.GatewayTemplate.Spec.TCPRoutes) > 0 {
 			// TCP is not supported atm


### PR DESCRIPTION
## Purpose
> Fix using the wrong cell instance for source label generation in Virtual Service.