### PR TITLE
Enable autoscaling by default in cellery-config

### DIFF
--- a/artifacts/09-config.yaml
+++ b/artifacts/09-config.yaml
@@ -71,7 +71,7 @@ data:
   cell-gateway-image: wso2cellery/cell-gateway
   oidc-filter-image: wso2cellery/envoy-oidc-filter
   skip-tls-verification: "true"
-  enable-autoscaling: "false"
+  enable-autoscaling: "true"
   cell-sts-config: |
     {
         "endpoint": "https://gateway.cellery-system:9443/api/identity/cellery-auth/v1.0/sts/token",

--- a/pkg/controller/gateway/gateway.go
+++ b/pkg/controller/gateway/gateway.go
@@ -597,7 +597,7 @@ func (h *gatewayHandler) updateConfig(obj interface{}) {
 	if enableAutoscaling, ok := configMap.Data["enable-autoscaling"]; ok {
 		conf.EnableAutoscaling = isAutoscalingEnabled(enableAutoscaling)
 	} else {
-		conf.EnableAutoscaling = false
+		conf.EnableAutoscaling = true
 	}
 
 	h.gatewayConfig = conf

--- a/pkg/controller/service/service.go
+++ b/pkg/controller/service/service.go
@@ -395,7 +395,7 @@ func (h *serviceHandler) updateConfig(obj interface{}) {
 	if enableAutoscaling, ok := configMap.Data["enable-autoscaling"]; ok {
 		conf.EnableAutoscaling = isAutoscalingEnabled(enableAutoscaling)
 	} else {
-		conf.EnableAutoscaling = false
+		conf.EnableAutoscaling = true
 	}
 
 	h.serviceConfig = conf


### PR DESCRIPTION
## Purpose
> Set `enable-autoscaling` flag to `true` by default.