### PR TITLE
original component service creation logic for composites

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -137,6 +137,7 @@ func main() {
 		meshClient,
 		compositeInformer,
 		serviceInformer,
+		k8sServiceInformer,
 		tokenServiceInformer,
 		secretInformer,
 		systemSecretInformer,

--- a/pkg/apis/mesh/register.go
+++ b/pkg/apis/mesh/register.go
@@ -36,9 +36,10 @@ const (
 	CompositeTokenServiceLabelKey = GroupName + "/composite-sts"
 
 	// Cellery Annotations
-	CellServicesAnnotationKey     = GroupName + "/cell-services"
-	CellDependenciesAnnotationKey = GroupName + "/cell-dependencies"
-	CellOriginalGatewaySvcKey     = GroupName + "/original-gw-svc"
+	CellServicesAnnotationKey        = GroupName + "/cell-services"
+	CellDependenciesAnnotationKey    = GroupName + "/cell-dependencies"
+	CellOriginalGatewaySvcKey        = GroupName + "/original-gw-svc"
+	CompositeOriginalComponentSvcKey = GroupName + "/original-component-svcs"
 
 	// Cellery System
 	SystemNamespace     = "cellery-system"

--- a/pkg/controller/composite/resources/k8s_service.go
+++ b/pkg/controller/composite/resources/k8s_service.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019 WSO2 Inc. (http:www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/cellery-io/mesh-controller/pkg/apis/mesh"
+	"github.com/cellery-io/mesh-controller/pkg/apis/mesh/v1alpha1"
+	"github.com/cellery-io/mesh-controller/pkg/controller"
+)
+
+func CreateOriginalComponentK8sService(composite *v1alpha1.Composite, compName string, targetPorts []int) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      K8sServiceName(compName),
+			Namespace: composite.Namespace,
+			Labels:    createLabelsForCurrentPodsWithPrevSvcName(composite, compName),
+			OwnerReferences: []metav1.OwnerReference{
+				*controller.CreateCompositeOwnerRef(composite),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:    *getAsContainerPorts(targetPorts),
+			Selector: createLabelsForCurrentPodsWithPrevSvcName(composite, compName),
+		},
+	}
+}
+
+func getAsContainerPorts(ports []int) *[]corev1.ServicePort {
+	var svcPorts []corev1.ServicePort
+	for _, port := range ports {
+		svcPorts = append(svcPorts, corev1.ServicePort{
+			Name:       controller.HTTPServiceName,
+			Protocol:   corev1.ProtocolTCP,
+			Port:       80,
+			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: int32(port)},
+		})
+	}
+	return &svcPorts
+}
+
+func createLabelsForCurrentPodsWithPrevSvcName(composite *v1alpha1.Composite, compName string) map[string]string {
+	//labels := make(map[string]string, len(composite.ObjectMeta.Labels)+1)
+	//for k, v := range composite.ObjectMeta.Labels {
+	//	labels[k] = v
+	//}
+	component := strings.Split(compName, "--")[1]
+	labels := map[string]string{
+		mesh.CellServiceLabelKey: fmt.Sprintf("%s--%s", composite.Name, component),
+		mesh.CompositeLabelKey:   composite.Name,
+	}
+
+	return labels
+}

--- a/pkg/controller/composite/resources/k8s_service_test.go
+++ b/pkg/controller/composite/resources/k8s_service_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 WSO2 Inc. (http:www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cellery-io/mesh-controller/pkg/apis/mesh/v1alpha1"
+	"github.com/cellery-io/mesh-controller/pkg/controller"
+)
+
+func TestCreateOriginalComponentK8sService(t *testing.T) {
+	composite := &v1alpha1.Composite{
+		Spec: v1alpha1.CompositeSpec{
+			ServiceTemplates: []v1alpha1.ServiceTemplateSpec{
+				{
+					Spec: v1alpha1.ServiceSpec{
+						Type:        "Deployment",
+						ServicePort: 8080,
+						Replicas:    &intOne,
+						Protocol:    "http",
+						Container: corev1.Container{
+							Name: "coNtaiNeR",
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8080,
+								},
+							},
+							Image: "izza/testcontainer",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	compName := "myhr--mycomponent"
+	targetPorts := []int{5005}
+
+	expected := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      K8sServiceName(compName),
+			Namespace: composite.Namespace,
+			Labels:    createLabelsForCurrentPodsWithPrevSvcName(composite, compName),
+			OwnerReferences: []metav1.OwnerReference{
+				*controller.CreateCompositeOwnerRef(composite),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:    *getAsContainerPorts(targetPorts),
+			Selector: createLabelsForCurrentPodsWithPrevSvcName(composite, compName),
+		},
+	}
+	actual := CreateOriginalComponentK8sService(composite, compName, targetPorts)
+
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("CreateOriginalComponentK8sService (-want, +got)\n%v", diff)
+	}
+}

--- a/pkg/controller/composite/resources/meta.go
+++ b/pkg/controller/composite/resources/meta.go
@@ -19,6 +19,8 @@
 package resources
 
 import (
+	"fmt"
+
 	"github.com/cellery-io/mesh-controller/pkg/apis/mesh"
 	"github.com/cellery-io/mesh-controller/pkg/apis/mesh/v1alpha1"
 )
@@ -78,4 +80,8 @@ func ServiceName(composite *v1alpha1.Composite, serviceTemplate v1alpha1.Service
 
 func SecretName(composite *v1alpha1.Composite) string {
 	return "composite-sts-secret"
+}
+
+func K8sServiceName(name string) string {
+	return fmt.Sprintf("%s-service", name)
 }


### PR DESCRIPTION
## Purpose
> Add the logic to create k8s services for original dependencies in traffic shifting, for composites. 